### PR TITLE
feat: set private key to deterministically create account

### DIFF
--- a/simulators/ethereum/rpc/main.go
+++ b/simulators/ethereum/rpc/main.go
@@ -11,12 +11,12 @@ import (
 
 var (
 	// parameters used for signing transactions
-	chainID  = big.NewInt(7)
+	chainID  = big.NewInt(1263227476)
 	gasPrice = big.NewInt(30 * params.GWei)
 
 	// would be nice to use a networkID that's different from chainID,
 	// but some clients don't support the distinction properly.
-	networkID = big.NewInt(7)
+	networkID = big.NewInt(1263227476)
 )
 
 var clientEnv = hivesim.Params{

--- a/simulators/ethereum/rpc/vault.go
+++ b/simulators/ethereum/rpc/vault.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"fmt"
 	"math/big"
 	"strings"
@@ -48,10 +49,22 @@ func newVault() *vault {
 
 // generateKey creates a new account key and stores it.
 func (v *vault) generateKey() common.Address {
-	key, err := crypto.GenerateKey()
-	if err != nil {
-		panic(fmt.Errorf("can't generate account key: %v", err))
+	curve := elliptic.P256()
+	x, _ := new(big.Int).SetString("87831664928590442425542245833375763255520659056538361531440198875786344494017", 10)
+	y, _ := new(big.Int).SetString("70474551846690540947106759554849067073517087752386060292615277549671377574265", 10)
+	d, _ := new(big.Int).SetString("49658758737278119559613755795134523823460045187650087773926355249395488702208", 10)
+
+	// Create a new private key object
+	key := &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: curve,
+			X:     x,
+			Y:     y,
+		},
+		D: d,
 	}
+
+	// 0x75454A4CcBb30bE745679F0abA5aB9D55769406a
 	addr := crypto.PubkeyToAddress(key.PublicKey)
 
 	v.mu.Lock()


### PR DESCRIPTION
This pr does the following:
- Set `chain_id` to KKRT so tx validation passes
- Due to this [issue](https://github.com/kkrt-labs/kakarot/issues/698) of unable to send ether to an address if it's not deployed in Kakarot, we set the receipient account address deterministically `0x75454A4CcBb30bE745679F0abA5aB9D55769406a` and pre-deploy it in the [hive genesis](https://github.com/kkrt-labs/kakarot-rpc/blob/4d401ad35043ec32e577278615d4b58b11c20d5a/crates/hive-utils/src/test_data/hive_genesis.json#L16) like any other EOA
- resolve https://github.com/kkrt-labs/kakarot-rpc/issues/482