### PR TITLE
fix: pull correct execution apis tests

### DIFF
--- a/simulators/ethereum/rpc-compat/Dockerfile
+++ b/simulators/ethereum/rpc-compat/Dockerfile
@@ -3,7 +3,11 @@ FROM golang:1-alpine as builder
 RUN apk add --update git ca-certificates gcc musl-dev linux-headers
 
 # Clone the tests repo.
-RUN git clone --depth 1 https://github.com/ethereum/execution-apis.git /execution-apis
+RUN git clone --depth 20 https://github.com/ethereum/execution-apis.git /execution-apis
+WORKDIR /execution-apis
+# Checkout the commit which doesn't include EIP4844.
+RUN git checkout 150a7b654f7f14d528fa5ee0fbcbc64fbe3f3745
+WORKDIR /
 
 # To run local tests, copy the directory into the same as the simulator and
 # uncomment the line below


### PR DESCRIPTION
Update the commit being pulled in order to exclude the EIP-4844.