### PR TITLE
fix: remove (client) from the rpc-compat name

### DIFF
--- a/simulators/ethereum/rpc-compat/main.go
+++ b/simulators/ethereum/rpc-compat/main.go
@@ -75,7 +75,7 @@ func runAllTests(t *hivesim.T, c *hivesim.Client, clientName string) {
 	for _, test := range tests {
 		test := test
 		t.Run(hivesim.TestSpec{
-			Name:        fmt.Sprintf("%s (%s)", test.name, clientName),
+			Name:        test.name,
 			Description: test.comment,
 			Run: func(t *hivesim.T) {
 				if err := runTest(t, c, &test); err != nil {

--- a/simulators/ethereum/rpc/main.go
+++ b/simulators/ethereum/rpc/main.go
@@ -113,18 +113,6 @@ interacting with one.`[1:],
 		AlwaysRun:   true,
 	})
 
-	// Add tests to launch LES servers.
-	serverParams := clientEnv.Set("HIVE_LES_SERVER", "1")
-	suite.Add(hivesim.ClientTestSpec{
-		Role:        "eth1_les_server",
-		Name:        "CLIENT as LES server",
-		Description: "This test launches an LES server.",
-		Parameters:  serverParams,
-		Files:       files,
-		Run:         func(t *hivesim.T, srv *hivesim.Client) { runLESTests(t, srv) },
-		AlwaysRun:   true,
-	})
-
 	sim := hivesim.New()
 	hivesim.MustRunSuite(sim, suite)
 }


### PR DESCRIPTION
remove the client name for the test name which caused some issues with regexp.